### PR TITLE
Fix regex to match on .js but not on .json

### DIFF
--- a/src/esbuildImportMetaUrlPlugin.ts
+++ b/src/esbuildImportMetaUrlPlugin.ts
@@ -7,7 +7,7 @@ export default <Plugin>{
   name: 'import.meta.url',
   setup ({ onLoad }) {
     // Help vite that bundles/move files in dev mode without touching `import.meta.url` which breaks asset urls
-    onLoad({ filter: /.*\.js/, namespace: 'file' }, async args => {
+    onLoad({ filter: /.*\.js$/, namespace: 'file' }, async args => {
       const code = fs.readFileSync(args.path, 'utf8')
 
       const assetImportMetaUrlRE = /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/g


### PR DESCRIPTION
I ran into the following error when adding an npm package that attempted to import a `json` file:

```
✘ [ERROR] Expected ";" but found ":"

    node_modules/@leanprover/unicode-input/dist/abbreviations.json:2:8:
      2 │     "{}": "{$CURSOR}",
        │         ^
        ╵         ;
```
What's happening here is that vite tries to parse the json file as javascript and fails. The reason is that this plugin's regex matches `.js` but also `.json`. (I don't fully understand the details...) Anyhow, a `$` at the end of the regex resolves the issue.