### PR TITLE
fix: regex to match only .js files

### DIFF
--- a/src/esbuildImportMetaUrlPlugin.ts
+++ b/src/esbuildImportMetaUrlPlugin.ts
@@ -7,7 +7,7 @@ export default <Plugin>{
   name: 'import.meta.url',
   setup ({ onLoad }) {
     // Help vite that bundles/move files in dev mode without touching `import.meta.url` which breaks asset urls
-    onLoad({ filter: /.*\.js/, namespace: 'file' }, async args => {
+    onLoad({ filter: /.*\.js$/, namespace: 'file' }, async args => {
       const code = fs.readFileSync(args.path, 'utf8')
 
       const assetImportMetaUrlRE = /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/g


### PR DESCRIPTION
the current regex matches .js files and any files that end with `.js`, for example, .json files which make the plugin throw syntax errors, This happened to me while running a project in the mono repo with turbo pack, and the plugin was matching the .json auto-generated files inside `.pnpm` folder and throwing syntax errors in the console and causing vite compilation to fail.